### PR TITLE
Set max date value to only accept 4 digits

### DIFF
--- a/src/lib/DateInput/DateInput.svelte
+++ b/src/lib/DateInput/DateInput.svelte
@@ -31,6 +31,7 @@
 	type="date"
 	class:embed
 	value={value ? dayjs(value).format("YYYY-MM-DD") : null}
+	max="9999-12-31"
 	on:change={handleChange}
 />
 


### PR DESCRIPTION
https://stackoverflow.com/questions/64660946/html-is-there-a-way-to-limit-the-year-to-4-digits-in-date-input

Obsidian applys the same restriction on properties date input.
![image](https://github.com/marcusolsson/obsidian-svelte/assets/73122375/2575d6a4-b774-46f2-8614-02db37ce41d5)
