### PR TITLE
Support pop-over components in pop out windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"prettier-plugin-svelte": "^2.7.0",
 		"svelte": "^3.44.0",
 		"svelte-check": "^2.7.1",
-		"svelte-portal": "^2.2.0",
 		"svelte-preprocess": "^4.10.6",
 		"tslib": "^2.3.1",
 		"typescript": "^4.7.4",

--- a/src/lib/Popover/Popover.svelte
+++ b/src/lib/Popover/Popover.svelte
@@ -84,7 +84,7 @@
 </script>
 
 {#if open}
-	<Portal target={document.body}>
+	<Portal target={anchorEl.ownerDocument.body}>
 		<div
 			class={className}
 			bind:this={popperEl}

--- a/src/lib/Popover/Popover.svelte
+++ b/src/lib/Popover/Popover.svelte
@@ -6,7 +6,7 @@
 		type OptionsGeneric,
 	} from "@popperjs/core";
 
-	import Portal from "svelte-portal";
+	import Portal from "src/mocks/Portal.svelte";
 	import { onDestroy } from "svelte";
 	import { useClickOutside } from "./useClickOutside";
 

--- a/src/lib/Popover/useClickOutside.ts
+++ b/src/lib/Popover/useClickOutside.ts
@@ -18,14 +18,14 @@ export function useClickOutside(
 		}
 	}
 
-	document.body.addEventListener("click", onClick);
+	element.ownerDocument.body.addEventListener("click", onClick);
 
 	return {
 		update(props: ClickOutsideProps) {
 			onClickOutside = props.onClickOutside;
 		},
 		destroy() {
-			document.body.removeEventListener("click", onClick);
+			element.ownerDocument.body.removeEventListener("click", onClick);
 		},
 	};
 }

--- a/src/lib/useClickOutside.ts
+++ b/src/lib/useClickOutside.ts
@@ -8,14 +8,14 @@ export function useClickOutside(
 		}
 	}
 
-	document.body.addEventListener("click", onClick);
+	element.ownerDocument.body.addEventListener("click", onClick);
 
 	return {
 		update(newCallbackFunction: () => void) {
 			callbackFunction = newCallbackFunction;
 		},
 		destroy() {
-			document.body.removeEventListener("click", onClick);
+			element.ownerDocument.body.removeEventListener("click", onClick);
 		},
 	};
 }

--- a/src/mocks/Portal.svelte
+++ b/src/mocks/Portal.svelte
@@ -1,0 +1,58 @@
+<script lang="ts" context="module">
+	import { tick } from "svelte";
+
+	// Usage: <div use:portal={'css selector'}> or <div use:portal={document.body}>
+	export function portal(el: HTMLElement, target: any = "body") {
+		let targetEl: any;
+		async function update(newTarget: any) {
+			target = newTarget;
+			if (typeof target === "string") {
+				targetEl = document.querySelector(target);
+				if (targetEl === null) {
+					await tick();
+					targetEl = document.querySelector(target);
+				}
+				if (targetEl === null) {
+					throw new Error(
+						`No element found matching css selector: "${target}"`,
+					);
+				}
+			} else if (target instanceof HTMLElement) {
+				targetEl = target;
+			} else if (el?.ownerDocument?.defaultView) {
+				if (target instanceof el.ownerDocument.defaultView.HTMLElement) {
+					targetEl = target;
+				}
+			} else {
+				throw new TypeError(
+					`Unknown portal target type: ${
+						target === null ? "null" : typeof target
+					}. Allowed types: string (CSS selector) or HTMLElement.`,
+				);
+			}
+			targetEl?.appendChild(el);
+			el.hidden = false;
+		}
+
+		function destroy() {
+			if (el.parentNode) {
+				el.parentNode.removeChild(el);
+			}
+		}
+
+		update(target);
+		return {
+			update,
+			destroy,
+		};
+	}
+</script>
+
+<script lang="ts">
+	// DOM Element or CSS Selector
+	export let target: any = "body";
+</script>
+
+<div use:portal={target} hidden>
+	<slot />
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,11 +1753,6 @@ svelte-hmr@^0.15.0:
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.15.0.tgz#c8304b5dd33f006415329d91470761d19417a324"
   integrity sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==
 
-svelte-portal@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/svelte-portal/-/svelte-portal-2.2.0.tgz#794bdd7626e88a7023cd0ff3832c547af827deaf"
-  integrity sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==
-
 svelte-preprocess@^4.0.0, svelte-preprocess@^4.10.6:
   version "4.10.7"
   resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz#3626de472f51ffe20c9bc71eff5a3da66797c362"


### PR DESCRIPTION
The pop-out window operates with distinct window and document objects. Therefore, instead of using `document.body` directly as the portal target, we need to use `element.ownerDocument.body` to enable the execution of Projects in the new window.

Please also note that my commit removed the upstream `svelte-portal` as it directly conducts `instanceof HTMLElement` check with the proposing `ownerDocument.body`, which would yield a `false` because we're calling the `instanceof` from the main window, but the `ownerDocument.body` is in another set.

See more:
https://obsidian.md/blog/how-to-update-plugins-to-support-pop-out-windows/
https://github.com/romkor/svelte-portal/issues/159

Will fix https://github.com/marcusolsson/obsidian-projects/pull/829