### PR TITLE
Add Datetime input

### DIFF
--- a/src/lib/DateInput/DateInput.svelte
+++ b/src/lib/DateInput/DateInput.svelte
@@ -13,12 +13,26 @@
 	 */
 	export let embed: boolean = false;
 
-	const dispatch = createEventDispatcher<{ change: Date | null }>();
+	const dispatch = createEventDispatcher<{
+		change: Date | null;
+		input: Date | null;
+	}>();
 
 	function handleChange(event: Event) {
 		if (event.currentTarget instanceof HTMLInputElement) {
 			dispatch(
 				"change",
+				event.currentTarget.value
+					? dayjs(event.currentTarget.value).toDate()
+					: null,
+			);
+		}
+	}
+
+	function handleInput(event: Event) {
+		if (event.currentTarget instanceof HTMLInputElement) {
+			dispatch(
+				"input",
 				event.currentTarget.value
 					? dayjs(event.currentTarget.value).toDate()
 					: null,
@@ -33,6 +47,7 @@
 	value={value ? dayjs(value).format("YYYY-MM-DD") : null}
 	max="9999-12-31"
 	on:change={handleChange}
+	on:input={handleInput}
 	on:blur
 />
 

--- a/src/lib/DatetimeInput/DatetimeInput.svelte
+++ b/src/lib/DatetimeInput/DatetimeInput.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { createEventDispatcher } from "svelte";
+	import dayjs from "dayjs";
+
+	/**
+	 * Specifies the date time value.
+	 */
+	export let value: Date | null;
+
+	/**
+	 * Specifies whether to remove decorations so that it can be embedded in other
+	 * components.
+	 */
+	export let embed: boolean = false;
+
+	const dispatch = createEventDispatcher<{ change: Date | null }>();
+
+	function handleChange(event: Event) {
+		if (event.currentTarget instanceof HTMLInputElement) {
+			dispatch(
+				"change",
+				event.currentTarget.value
+					? dayjs(event.currentTarget.value).toDate()
+					: null,
+			);
+		}
+	}
+</script>
+
+<input
+	type="datetime-local"
+	class:embed
+	value={value ? dayjs(value).format("YYYY-MM-DDHH:mm") : null}
+	max="9999-12-31T23:59"
+	on:change={handleChange}
+	on:blur
+/>
+
+<style>
+	input {
+		border-radius: 9999px;
+		border: 0;
+		background-color: var(--background-modifier-hover);
+		font-family: var(--font-default);
+		padding: 0.1em 0.6em;
+	}
+
+	.embed {
+		margin: 0 8px;
+	}
+</style>

--- a/src/lib/DatetimeInput/DatetimeInput.svelte
+++ b/src/lib/DatetimeInput/DatetimeInput.svelte
@@ -13,12 +13,26 @@
 	 */
 	export let embed: boolean = false;
 
-	const dispatch = createEventDispatcher<{ change: Date | null }>();
+	const dispatch = createEventDispatcher<{
+		change: Date | null;
+		input: Date | null;
+	}>();
 
 	function handleChange(event: Event) {
 		if (event.currentTarget instanceof HTMLInputElement) {
 			dispatch(
 				"change",
+				event.currentTarget.value
+					? dayjs(event.currentTarget.value).toDate()
+					: null,
+			);
+		}
+	}
+
+	function handleInput(event: Event) {
+		if (event.currentTarget instanceof HTMLInputElement) {
+			dispatch(
+				"input",
 				event.currentTarget.value
 					? dayjs(event.currentTarget.value).toDate()
 					: null,
@@ -33,6 +47,7 @@
 	value={value ? dayjs(value).format("YYYY-MM-DDTHH:mm") : null}
 	max="9999-12-31T23:59"
 	on:change={handleChange}
+	on:input={handleInput}
 	on:blur
 />
 

--- a/src/lib/DatetimeInput/DatetimeInput.svelte
+++ b/src/lib/DatetimeInput/DatetimeInput.svelte
@@ -30,7 +30,7 @@
 <input
 	type="datetime-local"
 	class:embed
-	value={value ? dayjs(value).format("YYYY-MM-DDHH:mm") : null}
+	value={value ? dayjs(value).format("YYYY-MM-DDTHH:mm") : null}
 	max="9999-12-31T23:59"
 	on:change={handleChange}
 	on:blur

--- a/src/lib/DatetimeInput/index.ts
+++ b/src/lib/DatetimeInput/index.ts
@@ -1,0 +1,1 @@
+export { default as DatetimeInput } from "./DatetimeInput.svelte";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,6 +5,7 @@ export { Card } from "./Card";
 export { Checkbox } from "./Checkbox";
 export { ColorInput } from "./ColorInput";
 export { DateInput } from "./DateInput";
+export { DatetimeInput } from "./DatetimeInput";
 export { Icon, IconButton, useIcon } from "./Icon";
 export { InternalLink, Link } from "./Link";
 export { Loading } from "./Loading";


### PR DESCRIPTION
Wrap `input[type='datetime-local']` just like the `DateInput`. Still a work-in-progress cauz there're some differences on the `on:change` event trigger between this and `input[type='date']` that need to be handled carefully.

Update: by listening to `input` rather than `change` event, DatetimeInput can now work as expected.

The max attr is set according to native Obsidian Properties UI.

![image](https://github.com/marcusolsson/obsidian-svelte/assets/73122375/923d99a3-511c-4604-b061-544c896102be)
