### PR TITLE
New checkable menu item design

### DIFF
--- a/src/lib/Popover/MenuItem.svelte
+++ b/src/lib/Popover/MenuItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Switch } from "../Switch";
 	import { useIcon } from "../Icon";
 
 	import { createEventDispatcher } from "svelte";
@@ -31,14 +30,16 @@
 	class:selected
 	on:mouseenter={() => (selected = true)}
 	on:mouseleave={() => (selected = false)}
-	on:click
+	on:click={() => {
+		if (checked !== undefined) checked = !checked;
+	}}
 	on:keypress
 >
-	{#if checked !== undefined}
-		<Switch {checked} on:check={({ detail: enabled }) => (checked = enabled)} />
-	{/if}
 	{#if icon}
 		<div class="menu-item-icon" use:useIcon={icon} />
 	{/if}
 	<div class="menu-item-title">{label}</div>
+	{#if checked !== undefined && checked}
+		<div class="menu-item-icon mod-checked" use:useIcon={"check"} />
+	{/if}
 </div>


### PR DESCRIPTION
Use inline check mark instead of a switch button.

Obsidian API also provides [`setChecked()`](https://github.com/obsidianmd/obsidian-api/blob/8b2eda0f24285636c8aa116972643e5233a23dc1/obsidian.d.ts#L2529
), and here's the corresponding visualization.

![image](https://github.com/marcusolsson/obsidian-svelte/assets/73122375/2cfe65a2-68df-49f8-bcf4-684a52ea59a2)
