### PR TITLE
Fix InternalLink failure on mobile (Android)

### DIFF
--- a/src/lib/Link/InternalLink.svelte
+++ b/src/lib/Link/InternalLink.svelte
@@ -43,6 +43,7 @@
 	rel="noopener"
 	on:click={(event) => {
 		event.stopPropagation();
+		event.preventDefault();
 
 		dispatch("open", {
 			linkText,


### PR DESCRIPTION
This is a fix for a very weird Android bug:

https://github.com/marcusolsson/obsidian-projects/issues/780

The best I could tell, for some reason `event.stopPropagation()` is enough to stop desktop electron from trying to open the default anchor href, but not on android. In obsidian-projects, the InternalLink `on:open` handler (eg, [this one](https://github.com/marcusolsson/obsidian-projects/blob/184b7e5e667024f0838e6d526f2434fd44312f51/src/ui/views/Board/components/Board/CardList.svelte#L114)) gets triggered and then the browser _also_ navigates to the href (and fails with a 404, because the obsidian path its not a real local file).

`event.preventDefault()` stops this from happening. With this fix, obsidian-projects note links from InternalLinks in Board, Gallery and Calendar view all work as expected based on my testing.

If there's a good reason not to always have `event.preventDefault()`, the event object should probably be passed to the open handler for topical treatment